### PR TITLE
Add climate/select platforms, parallel API, weather sensors v0.10.0

### DIFF
--- a/custom_components/hoval_connect/__init__.py
+++ b/custom_components/hoval_connect/__init__.py
@@ -4,20 +4,28 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import DeviceInfo
 
 from .api import HovalConnectApi
-from .const import DOMAIN
-from .coordinator import HovalDataCoordinator
+from .const import CIRCUIT_TYPE_NAMES, CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN
+from .coordinator import HovalCircuitData, HovalDataCoordinator, HovalPlantData
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.FAN, Platform.SENSOR]
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.CLIMATE,
+    Platform.FAN,
+    Platform.SELECT,
+    Platform.SENSOR,
+]
 
 type HovalConnectConfigEntry = ConfigEntry[HovalRuntimeData]
 
@@ -30,12 +38,45 @@ class HovalRuntimeData:
     api: HovalConnectApi
 
 
+def plant_device_info(plant_data: HovalPlantData) -> DeviceInfo:
+    """Build DeviceInfo for a plant device."""
+    return DeviceInfo(
+        identifiers={(DOMAIN, plant_data.plant_id)},
+        name=f"Hoval {plant_data.name}",
+        manufacturer="Hoval",
+        model="Plant",
+    )
+
+
+def circuit_device_info(
+    plant_id: str, circuit_data: HovalCircuitData,
+) -> DeviceInfo:
+    """Build DeviceInfo for a circuit device."""
+    model = CIRCUIT_TYPE_NAMES.get(
+        circuit_data.circuit_type, circuit_data.circuit_type
+    )
+    return DeviceInfo(
+        identifiers={(DOMAIN, f"{plant_id}_{circuit_data.path}")},
+        name=f"Hoval {circuit_data.name}",
+        manufacturer="Hoval",
+        model=model,
+        via_device=(DOMAIN, plant_id),
+    )
+
+
+def _get_scan_interval(entry: HovalConnectConfigEntry) -> timedelta:
+    """Get the scan interval from options or use default."""
+    seconds = entry.options.get(CONF_SCAN_INTERVAL, int(DEFAULT_SCAN_INTERVAL.total_seconds()))
+    return timedelta(seconds=seconds)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: HovalConnectConfigEntry) -> bool:
     """Set up Hoval Connect from a config entry."""
     session = async_get_clientsession(hass)
     api = HovalConnectApi(session, entry.data["email"], entry.data["password"])
 
     coordinator = HovalDataCoordinator(hass, api)
+    coordinator.update_interval = _get_scan_interval(entry)
 
     await coordinator.async_config_entry_first_refresh()
 
@@ -54,7 +95,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: HovalConnectConfigEntry)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    # Listen for options changes to update polling interval dynamically
+    entry.async_on_unload(entry.add_update_listener(_async_options_updated))
+
     return True
+
+
+async def _async_options_updated(
+    hass: HomeAssistant, entry: HovalConnectConfigEntry,
+) -> None:
+    """Handle options update — adjust polling interval without reload."""
+    coordinator = entry.runtime_data.coordinator
+    coordinator.update_interval = _get_scan_interval(entry)
+    _LOGGER.debug("Polling interval updated to %s", coordinator.update_interval)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: HovalConnectConfigEntry) -> bool:

--- a/custom_components/hoval_connect/binary_sensor.py
+++ b/custom_components/hoval_connect/binary_sensor.py
@@ -7,12 +7,10 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import HovalConnectConfigEntry
-from .const import DOMAIN
+from . import HovalConnectConfigEntry, plant_device_info
 from .coordinator import HovalDataCoordinator, HovalPlantData
 
 
@@ -49,12 +47,7 @@ class HovalPlantOnline(CoordinatorEntity[HovalDataCoordinator], BinarySensorEnti
         super().__init__(coordinator)
         self._plant_id = plant_id
         self._attr_unique_id = f"{plant_id}_online"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, plant_id)},
-            name=f"Hoval {plant_data.name}",
-            manufacturer="Hoval",
-            model="Plant",
-        )
+        self._attr_device_info = plant_device_info(plant_data)
 
     @property
     def is_on(self) -> bool | None:
@@ -82,12 +75,7 @@ class HovalPlantError(CoordinatorEntity[HovalDataCoordinator], BinarySensorEntit
         super().__init__(coordinator)
         self._plant_id = plant_id
         self._attr_unique_id = f"{plant_id}_error"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, plant_id)},
-            name=f"Hoval {plant_data.name}",
-            manufacturer="Hoval",
-            model="Plant",
-        )
+        self._attr_device_info = plant_device_info(plant_data)
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/hoval_connect/climate.py
+++ b/custom_components/hoval_connect/climate.py
@@ -1,0 +1,200 @@
+"""Climate platform for Hoval Connect (HK heating circuits)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from homeassistant.components.climate import (
+    ClimateEntity,
+    ClimateEntityFeature,
+    HVACAction,
+    HVACMode,
+)
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import HovalConnectConfigEntry, circuit_device_info
+from .const import (
+    CIRCUIT_TYPE_HK,
+    CONF_OVERRIDE_DURATION,
+    DEFAULT_OVERRIDE_DURATION,
+    OPERATION_MODE_REGULAR,
+    OPERATION_MODE_STANDBY,
+)
+from .coordinator import HovalCircuitData, HovalDataCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: HovalConnectConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Hoval climate entities for heating circuits."""
+    coordinator = entry.runtime_data.coordinator
+
+    entities: list[HovalClimate] = []
+    for plant_id, plant_data in coordinator.data.plants.items():
+        for path, circuit in plant_data.circuits.items():
+            if circuit.circuit_type == CIRCUIT_TYPE_HK:
+                entities.append(
+                    HovalClimate(coordinator, entry, plant_id, path, circuit)
+                )
+
+    async_add_entities(entities)
+
+
+class HovalClimate(CoordinatorEntity[HovalDataCoordinator], ClimateEntity):
+    """Hoval heating circuit climate entity."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Heating"
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_target_temperature_step = 0.5
+    _attr_min_temp = 5.0
+    _attr_max_temp = 30.0
+    _attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF, HVACMode.AUTO]
+    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
+    _enable_turn_on_off_backwards_compat = False
+
+    def __init__(
+        self,
+        coordinator: HovalDataCoordinator,
+        entry: HovalConnectConfigEntry,
+        plant_id: str,
+        circuit_path: str,
+        circuit_data: HovalCircuitData,
+    ) -> None:
+        """Initialize the climate entity."""
+        super().__init__(coordinator)
+        self._entry = entry
+        self._plant_id = plant_id
+        self._circuit_path = circuit_path
+        self._attr_unique_id = f"{plant_id}_{circuit_path}_climate"
+        self._attr_device_info = circuit_device_info(plant_id, circuit_data)
+
+    @property
+    def _circuit(self) -> HovalCircuitData | None:
+        """Get current circuit data from coordinator."""
+        plant = self.coordinator.data.plants.get(self._plant_id)
+        if plant is None:
+            return None
+        return plant.circuits.get(self._circuit_path)
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self._circuit is not None
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the current temperature."""
+        circuit = self._circuit
+        if circuit is None:
+            return None
+        # Try live value first, fall back to circuit data
+        val = circuit.live_values.get("actualTemperature") or circuit.live_values.get("roomTemperature")
+        if val is not None:
+            try:
+                return float(val)
+            except (ValueError, TypeError):
+                return None
+        return None
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the target temperature."""
+        circuit = self._circuit
+        if circuit is None:
+            return None
+        val = circuit.live_values.get("targetTemperature")
+        if val is not None:
+            try:
+                return float(val)
+            except (ValueError, TypeError):
+                pass
+        # Fall back to program value (temperature for HK circuits)
+        if circuit.program_air_volume is not None:
+            return float(circuit.program_air_volume)
+        return None
+
+    @property
+    def hvac_mode(self) -> HVACMode | None:
+        """Return the current HVAC mode."""
+        circuit = self._circuit
+        if circuit is None:
+            return None
+        override = self.coordinator.get_mode_override(self._circuit_path)
+        mode = override if override is not None else circuit.operation_mode
+        if mode == OPERATION_MODE_STANDBY:
+            return HVACMode.OFF
+        # If a time program is active, show as AUTO
+        prog = circuit.active_program
+        if prog in ("week1", "week2", "ecoMode", "tteControlled", "timePrograms"):
+            return HVACMode.AUTO
+        return HVACMode.HEAT
+
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        """Return the current HVAC action."""
+        circuit = self._circuit
+        if circuit is None:
+            return None
+        override = self.coordinator.get_mode_override(self._circuit_path)
+        mode = override if override is not None else circuit.operation_mode
+        if mode == OPERATION_MODE_STANDBY:
+            return HVACAction.OFF
+        # Check circuit status from live values
+        status = circuit.live_values.get("circuitStatus", "").upper()
+        if status == "HEATING":
+            return HVACAction.HEATING
+        if status == "COOLING":
+            return HVACAction.COOLING
+        return HVACAction.IDLE
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set HVAC mode."""
+        async with self.coordinator.control_lock:
+            if hvac_mode == HVACMode.OFF:
+                await self.coordinator.api.set_circuit_mode(
+                    self._plant_id, self._circuit_path, OPERATION_MODE_STANDBY,
+                )
+                self.coordinator.set_mode_override(
+                    self._circuit_path, OPERATION_MODE_STANDBY,
+                )
+            elif hvac_mode in (HVACMode.AUTO, HVACMode.HEAT):
+                await self.coordinator.api.reset_circuit(
+                    self._plant_id, self._circuit_path,
+                )
+                self.coordinator.set_mode_override(
+                    self._circuit_path, OPERATION_MODE_REGULAR,
+                )
+            self.async_write_ha_state()
+            await asyncio.sleep(2)
+            await self.coordinator.async_request_refresh()
+
+    async def async_set_temperature(self, **kwargs) -> None:
+        """Set new target temperature via temporary change."""
+        temperature = kwargs.get("temperature")
+        if temperature is None:
+            return
+        duration = self._entry.options.get(
+            CONF_OVERRIDE_DURATION, DEFAULT_OVERRIDE_DURATION,
+        )
+        async with self.coordinator.control_lock:
+            await self.coordinator.api.set_temporary_change(
+                self._plant_id,
+                self._circuit_path,
+                value=int(temperature * 10),  # API uses tenths of degree for HK
+                duration=duration,
+            )
+            self.coordinator.set_mode_override(
+                self._circuit_path, OPERATION_MODE_REGULAR,
+            )
+            self.async_write_ha_state()
+            await asyncio.sleep(2)
+            await self.coordinator.async_request_refresh()

--- a/custom_components/hoval_connect/config_flow.py
+++ b/custom_components/hoval_connect/config_flow.py
@@ -12,12 +12,14 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from .api import HovalApiError, HovalAuthError, HovalConnectApi
 from .const import (
     CONF_OVERRIDE_DURATION,
+    CONF_SCAN_INTERVAL,
     CONF_TURN_ON_MODE,
     DEFAULT_OVERRIDE_DURATION,
     DEFAULT_TURN_ON_MODE,
     DOMAIN,
     DURATION_FOUR_HOURS,
     DURATION_MIDNIGHT,
+    SCAN_INTERVAL_OPTIONS,
     TURN_ON_RESUME,
     TURN_ON_WEEK1,
     TURN_ON_WEEK2,
@@ -139,6 +141,9 @@ class HovalConnectOptionsFlow(OptionsFlow):
         current_turn_on = self.config_entry.options.get(
             CONF_TURN_ON_MODE, DEFAULT_TURN_ON_MODE
         )
+        current_interval = self.config_entry.options.get(
+            CONF_SCAN_INTERVAL, 60
+        )
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
@@ -158,6 +163,10 @@ class HovalConnectOptionsFlow(OptionsFlow):
                         DURATION_FOUR_HOURS: "4 hours",
                         DURATION_MIDNIGHT: "Until midnight",
                     }),
+                    vol.Required(
+                        CONF_SCAN_INTERVAL,
+                        default=current_interval,
+                    ): vol.In(SCAN_INTERVAL_OPTIONS),
                 }
             ),
         )

--- a/custom_components/hoval_connect/const.py
+++ b/custom_components/hoval_connect/const.py
@@ -17,6 +17,14 @@ PLANT_TOKEN_TTL = timedelta(minutes=12)
 
 # Polling interval
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=60)
+CONF_SCAN_INTERVAL = "scan_interval"
+SCAN_INTERVAL_OPTIONS = {30: "30 seconds", 60: "60 seconds", 120: "2 minutes", 300: "5 minutes"}
+
+# Program cache TTL — programs change rarely, no need to fetch every poll
+PROGRAM_CACHE_TTL = timedelta(minutes=5)
+
+# HTTP request timeout (seconds)
+REQUEST_TIMEOUT = 30
 
 # Circuit types
 CIRCUIT_TYPE_HV = "HV"
@@ -30,9 +38,23 @@ CIRCUIT_TYPE_PS = "PS"
 CIRCUIT_TYPE_GW = "GW"
 
 # Supported circuit types for this integration
-SUPPORTED_CIRCUIT_TYPES = {CIRCUIT_TYPE_HV}
+SUPPORTED_CIRCUIT_TYPES = {CIRCUIT_TYPE_HV, CIRCUIT_TYPE_HK}
+
+# Human-readable names for circuit types
+CIRCUIT_TYPE_NAMES = {
+    CIRCUIT_TYPE_HV: "HomeVent",
+    CIRCUIT_TYPE_HK: "Heating Circuit",
+    CIRCUIT_TYPE_BL: "Boiler",
+    CIRCUIT_TYPE_WW: "Hot Water",
+    CIRCUIT_TYPE_FRIWA: "Fresh Water",
+    CIRCUIT_TYPE_SOL: "Solar",
+    CIRCUIT_TYPE_SOLB: "Solar Buffer",
+    CIRCUIT_TYPE_PS: "Pool",
+    CIRCUIT_TYPE_GW: "Gateway",
+}
 
 # Hoval operation modes
+OPERATION_MODE_REGULAR = "REGULAR"
 OPERATION_MODE_STANDBY = "standby"
 
 # Temporary change duration options (API enum)

--- a/custom_components/hoval_connect/coordinator.py
+++ b/custom_components/hoval_connect/coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
@@ -15,7 +16,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from homeassistant.util import dt as dt_util
 
 from .api import HovalApiError, HovalAuthError, HovalConnectApi
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, SUPPORTED_CIRCUIT_TYPES
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, PROGRAM_CACHE_TTL, SUPPORTED_CIRCUIT_TYPES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -96,6 +97,15 @@ class HovalCircuitData:
 
 
 @dataclass
+class HovalWeatherData:
+    """Parsed weather forecast data for a plant."""
+
+    weather_type: str | None = None
+    outside_temperature: float | None = None
+    outside_temperature_min: float | None = None
+
+
+@dataclass
 class HovalPlantData:
     """Parsed data for a single plant."""
 
@@ -106,6 +116,7 @@ class HovalPlantData:
     circuits: dict[str, HovalCircuitData] = field(default_factory=dict)
     latest_event: HovalEventData | None = None
     events: list[HovalEventData] = field(default_factory=list)
+    weather: HovalWeatherData | None = None
 
 
 @dataclass
@@ -167,6 +178,9 @@ class HovalDataCoordinator(DataUpdateCoordinator[HovalData]):
         # Optimistic mode override per circuit (set by control actions,
         # cleared on next poll). Key: circuit_path, value: operation mode string.
         self._mode_override: dict[str, str] = {}
+        # Program cache: key=circuit_path, value=(programs_data, timestamp)
+        self._program_cache: dict[str, tuple[Any, float]] = {}
+        self._program_cache_ttl = PROGRAM_CACHE_TTL.total_seconds()
 
     def set_mode_override(self, circuit_path: str, mode: str) -> None:
         """Set optimistic mode override after a control action."""
@@ -202,7 +216,7 @@ class HovalDataCoordinator(DataUpdateCoordinator[HovalData]):
                 # Skip all API calls when plant is offline
                 if not plant_data.is_online:
                     # Invalidate cached PAT so we get a fresh token when back
-                    self.api._pat_cache.pop(plant_id, None)
+                    self.api.invalidate_plant_token(plant_id)
                     data.plants[plant_id] = plant_data
                     continue
 
@@ -223,19 +237,27 @@ class HovalDataCoordinator(DataUpdateCoordinator[HovalData]):
                     ),
                 )
 
+                # Build list of supported circuits
+                supported_circuits: list[tuple[str, str, dict]] = []
                 for circuit in circuits_raw:
                     ctype = circuit.get("type", "")
                     if ctype not in SUPPORTED_CIRCUIT_TYPES:
                         continue
                     if not circuit.get("selectable", False):
                         continue
-
                     path = circuit["path"]
                     _LOGGER.debug(
                         "Circuit %s raw: %s",
                         path,
                         {k: v for k, v in circuit.items() if k != "name"},
                     )
+                    supported_circuits.append((path, ctype, circuit))
+
+                # Fetch live values + programs for all circuits in parallel
+                async def _fetch_circuit(
+                    path: str, ctype: str, circuit: dict,
+                    _plant_id: str = plant_id,
+                ) -> HovalCircuitData:
                     circuit_data = HovalCircuitData(
                         circuit_type=ctype,
                         path=path,
@@ -248,20 +270,38 @@ class HovalDataCoordinator(DataUpdateCoordinator[HovalData]):
                         has_error=circuit.get("hasError", False),
                     )
 
-                    try:
-                        live_values = await self.api.get_live_values(
-                            plant_id, path, ctype
+                    # Check program cache
+                    cached_prog = self._program_cache.get(path)
+                    need_programs = (
+                        cached_prog is None
+                        or time.time() - cached_prog[1] > self._program_cache_ttl
+                    )
+
+                    # Fetch live values (always) + programs (only if cache expired)
+                    live_task = self.api.get_live_values(_plant_id, path, ctype)
+                    if need_programs:
+                        prog_task = self.api.get_programs(_plant_id, path)
+                        results = await asyncio.gather(
+                            live_task, prog_task, return_exceptions=True,
                         )
+                    else:
+                        live_result = await asyncio.gather(
+                            live_task, return_exceptions=True,
+                        )
+                        results = [live_result[0], cached_prog[0]]
+
+                    if not isinstance(results[0], BaseException):
                         circuit_data.live_values = {
-                            v["key"]: v["value"] for v in live_values
+                            v["key"]: v["value"] for v in results[0]
                         }
                         _LOGGER.debug("Circuit %s live_values: %s", path, circuit_data.live_values)
-                    except HovalApiError:
+                    else:
                         _LOGGER.debug("Live values not available for %s", path)
 
-                    # Fetch time programs to resolve currently active phase
-                    try:
-                        programs = await self.api.get_programs(plant_id, path)
+                    programs = results[1]
+                    if not isinstance(programs, BaseException):
+                        if need_programs:
+                            self._program_cache[path] = (programs, time.time())
                         now = dt_util.now()
                         week_name, day_name, phase_value = (
                             _resolve_active_program_value(programs, now)
@@ -269,56 +309,87 @@ class HovalDataCoordinator(DataUpdateCoordinator[HovalData]):
                         circuit_data.active_week_name = week_name
                         circuit_data.active_day_program_name = day_name
                         circuit_data.program_air_volume = phase_value
-                    except HovalApiError:
-                        _LOGGER.debug("Programs endpoint not available for %s", path)
+                    else:
+                        _LOGGER.debug("Programs not available for %s", path)
 
-                    if circuit_data.has_error:
+                    return circuit_data
+
+                # Run all circuit fetches in parallel
+                circuit_results = await asyncio.gather(
+                    *[
+                        _fetch_circuit(path, ctype, circ)
+                        for path, ctype, circ in supported_circuits
+                    ],
+                    return_exceptions=True,
+                )
+                for result in circuit_results:
+                    if isinstance(result, BaseException):
+                        _LOGGER.debug("Circuit fetch failed: %s", result)
+                        continue
+                    if result.has_error:
                         plant_data.has_error = True
+                    plant_data.circuits[result.path] = result
 
-                    plant_data.circuits[path] = circuit_data
+                # Fetch plant events + weather in parallel
+                latest_task = self.api.get_latest_event(plant_id)
+                events_task = self.api.get_events(plant_id)
+                weather_task = self.api.get_weather(plant_id)
+                ev_results = await asyncio.gather(
+                    latest_task, events_task, weather_task,
+                    return_exceptions=True,
+                )
 
-                # Fetch plant events
-                try:
-                    latest_raw = await self.api.get_latest_event(plant_id)
-                    if latest_raw:
-                        plant_data.latest_event = HovalEventData(
-                            event_type=latest_raw.get("eventType"),
-                            message=latest_raw.get("message"),
-                            timestamp=latest_raw.get("timestamp"),
-                            circuit_path=latest_raw.get("circuitPath"),
-                            is_active=latest_raw.get("isActive", False),
-                        )
-                        _LOGGER.debug(
-                            "Latest event: type=%s active=%s",
-                            latest_raw.get("eventType"),
-                            latest_raw.get("isActive"),
-                        )
-                except HovalApiError:
+                if not isinstance(ev_results[0], BaseException) and ev_results[0]:
+                    latest_raw = ev_results[0]
+                    plant_data.latest_event = HovalEventData(
+                        event_type=latest_raw.get("eventType"),
+                        message=latest_raw.get("message"),
+                        timestamp=latest_raw.get("timestamp"),
+                        circuit_path=latest_raw.get("circuitPath"),
+                        is_active=latest_raw.get("isActive", False),
+                    )
+                    _LOGGER.debug(
+                        "Latest event: type=%s active=%s",
+                        latest_raw.get("eventType"),
+                        latest_raw.get("isActive"),
+                    )
+                elif isinstance(ev_results[0], BaseException):
                     _LOGGER.debug("Events endpoint not available for %s", plant_id)
 
-                try:
-                    events_raw = await self.api.get_events(plant_id)
-                    if events_raw:
-                        # Keep only the most recent 10 events
-                        for ev in events_raw[:10]:
-                            plant_data.events.append(HovalEventData(
-                                event_type=ev.get("eventType"),
-                                message=ev.get("message"),
-                                timestamp=ev.get("timestamp"),
-                                circuit_path=ev.get("circuitPath"),
-                                is_active=ev.get("isActive", False),
-                            ))
-                        # Set has_error if any active blocking/locking event
-                        for ev in plant_data.events:
-                            if ev.is_active and ev.event_type in (
-                                "blocking", "locking"
-                            ):
-                                plant_data.has_error = True
-                                break
-                except HovalApiError:
+                if not isinstance(ev_results[1], BaseException) and ev_results[1]:
+                    events_raw = ev_results[1]
+                    for ev in events_raw[:10]:
+                        plant_data.events.append(HovalEventData(
+                            event_type=ev.get("eventType"),
+                            message=ev.get("message"),
+                            timestamp=ev.get("timestamp"),
+                            circuit_path=ev.get("circuitPath"),
+                            is_active=ev.get("isActive", False),
+                        ))
+                    for ev in plant_data.events:
+                        if ev.is_active and ev.event_type in (
+                            "blocking", "locking"
+                        ):
+                            plant_data.has_error = True
+                            break
+                elif isinstance(ev_results[1], BaseException):
                     _LOGGER.debug(
-                        "Events list endpoint not available for %s", plant_id
+                        "Events list not available for %s", plant_id
                     )
+
+                # Weather forecast (index 2)
+                if not isinstance(ev_results[2], BaseException) and ev_results[2]:
+                    weather_list = ev_results[2]
+                    # First entry is current/nearest forecast
+                    if isinstance(weather_list, list) and weather_list:
+                        w = weather_list[0]
+                        plant_data.weather = HovalWeatherData(
+                            weather_type=w.get("weatherType"),
+                            outside_temperature=w.get("outsideTemperature"),
+                            outside_temperature_min=w.get("outsideTemperatureMin"),
+                        )
+                elif isinstance(ev_results[2], BaseException):
+                    _LOGGER.debug("Weather not available for %s", plant_id)
 
                 data.plants[plant_id] = plant_data
 

--- a/custom_components/hoval_connect/manifest.json
+++ b/custom_components/hoval_connect/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/trcyberoptic/hoval-connect-api/issues",
   "requirements": [],
-  "version": "0.9.0"
+  "version": "0.10.0"
 }

--- a/custom_components/hoval_connect/select.py
+++ b/custom_components/hoval_connect/select.py
@@ -1,0 +1,103 @@
+"""Select platform for Hoval Connect (program selection)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import HovalConnectConfigEntry, circuit_device_info
+from .const import OPERATION_MODE_REGULAR
+from .coordinator import HovalCircuitData, HovalDataCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# Programs available via the API
+PROGRAM_OPTIONS = ["week1", "week2", "ecoMode", "standby", "constant"]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: HovalConnectConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Hoval select entities."""
+    coordinator = entry.runtime_data.coordinator
+
+    entities: list[HovalProgramSelect] = []
+    for plant_id, plant_data in coordinator.data.plants.items():
+        for path, circuit in plant_data.circuits.items():
+            entities.append(
+                HovalProgramSelect(coordinator, plant_id, path, circuit)
+            )
+
+    async_add_entities(entities)
+
+
+class HovalProgramSelect(CoordinatorEntity[HovalDataCoordinator], SelectEntity):
+    """Select entity for choosing the active program on a circuit."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "program"
+    _attr_icon = "mdi:format-list-bulleted"
+    _attr_options = PROGRAM_OPTIONS
+
+    def __init__(
+        self,
+        coordinator: HovalDataCoordinator,
+        plant_id: str,
+        circuit_path: str,
+        circuit_data: HovalCircuitData,
+    ) -> None:
+        """Initialize the select entity."""
+        super().__init__(coordinator)
+        self._plant_id = plant_id
+        self._circuit_path = circuit_path
+        self._attr_unique_id = f"{plant_id}_{circuit_path}_program"
+        self._attr_device_info = circuit_device_info(plant_id, circuit_data)
+
+    @property
+    def _circuit(self) -> HovalCircuitData | None:
+        """Get current circuit data from coordinator."""
+        plant = self.coordinator.data.plants.get(self._plant_id)
+        if plant is None:
+            return None
+        return plant.circuits.get(self._circuit_path)
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self._circuit is not None
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the currently active program."""
+        circuit = self._circuit
+        if circuit is None:
+            return None
+        return circuit.active_program
+
+    async def async_select_option(self, option: str) -> None:
+        """Set the active program."""
+        _LOGGER.debug(
+            "Setting program to %s for %s", option, self._circuit_path,
+        )
+        async with self.coordinator.control_lock:
+            await self.coordinator.api.set_program(
+                self._plant_id, self._circuit_path, option,
+            )
+            if option != "standby":
+                self.coordinator.set_mode_override(
+                    self._circuit_path, OPERATION_MODE_REGULAR,
+                )
+            else:
+                self.coordinator.set_mode_override(
+                    self._circuit_path, "standby",
+                )
+            self.async_write_ha_state()
+            await asyncio.sleep(2)
+            await self.coordinator.async_request_refresh()

--- a/custom_components/hoval_connect/sensor.py
+++ b/custom_components/hoval_connect/sensor.py
@@ -12,14 +12,12 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import PERCENTAGE, UnitOfTemperature
+from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfTemperature
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import HovalConnectConfigEntry
-from .const import DOMAIN
+from . import HovalConnectConfigEntry, circuit_device_info, plant_device_info
 from .coordinator import HovalCircuitData, HovalDataCoordinator, HovalPlantData
 
 
@@ -79,15 +77,24 @@ CIRCUIT_SENSOR_DESCRIPTIONS: tuple[HovalSensorEntityDescription, ...] = (
         value_fn=lambda c: c.live_values.get("humidityTarget"),
     ),
     HovalSensorEntityDescription(
+        key="operation_mode",
+        translation_key="operation_mode",
+        icon="mdi:cog",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda c: c.operation_mode,
+    ),
+    HovalSensorEntityDescription(
         key="active_week_program",
         translation_key="active_week_program",
         icon="mdi:calendar-week",
+        entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda c: c.active_week_name,
     ),
     HovalSensorEntityDescription(
         key="active_day_program",
         translation_key="active_day_program",
         icon="mdi:calendar-today",
+        entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda c: c.active_day_program_name,
     ),
     HovalSensorEntityDescription(
@@ -96,6 +103,7 @@ CIRCUIT_SENSOR_DESCRIPTIONS: tuple[HovalSensorEntityDescription, ...] = (
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:fan-clock",
+        entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda c: c.program_air_volume,
     ),
 )
@@ -105,18 +113,21 @@ PLANT_SENSOR_DESCRIPTIONS: tuple[HovalPlantSensorEntityDescription, ...] = (
         key="latest_event_type",
         translation_key="latest_event_type",
         icon="mdi:alert-circle-outline",
+        entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda p: p.latest_event.event_type if p.latest_event else None,
     ),
     HovalPlantSensorEntityDescription(
         key="latest_event_message",
         translation_key="latest_event_message",
         icon="mdi:message-alert-outline",
+        entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda p: p.latest_event.message if p.latest_event else None,
     ),
     HovalPlantSensorEntityDescription(
         key="latest_event_time",
         translation_key="latest_event_time",
         device_class=SensorDeviceClass.TIMESTAMP,
+        entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda p: p.latest_event.timestamp if p.latest_event else None,
     ),
     HovalPlantSensorEntityDescription(
@@ -125,6 +136,20 @@ PLANT_SENSOR_DESCRIPTIONS: tuple[HovalPlantSensorEntityDescription, ...] = (
         icon="mdi:alert",
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda p: sum(1 for e in p.events if e.is_active),
+    ),
+    HovalPlantSensorEntityDescription(
+        key="weather_condition",
+        translation_key="weather_condition",
+        icon="mdi:weather-partly-cloudy",
+        value_fn=lambda p: p.weather.weather_type if p.weather else None,
+    ),
+    HovalPlantSensorEntityDescription(
+        key="weather_temperature",
+        translation_key="weather_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda p: p.weather.outside_temperature if p.weather else None,
     ),
 )
 
@@ -177,13 +202,7 @@ class HovalCircuitSensor(CoordinatorEntity[HovalDataCoordinator], SensorEntity):
         self._plant_id = plant_id
         self._circuit_path = circuit_path
         self._attr_unique_id = f"{plant_id}_{circuit_path}_{description.key}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{plant_id}_{circuit_path}")},
-            name=f"Hoval {circuit_data.name}",
-            manufacturer="Hoval",
-            model=f"HomeVent ({circuit_data.circuit_type})",
-            via_device=(DOMAIN, plant_id),
-        )
+        self._attr_device_info = circuit_device_info(plant_id, circuit_data)
 
     @property
     def _circuit(self) -> HovalCircuitData | None:
@@ -207,7 +226,7 @@ class HovalCircuitSensor(CoordinatorEntity[HovalDataCoordinator], SensorEntity):
         val = self.entity_description.value_fn(circuit)
         if val is None:
             return None
-        # String sensors (program names) return as-is
+        # String sensors (program names, operation mode) return as-is
         if self.entity_description.native_unit_of_measurement is None:
             return str(val)
         try:
@@ -234,12 +253,7 @@ class HovalPlantSensor(CoordinatorEntity[HovalDataCoordinator], SensorEntity):
         self.entity_description = description
         self._plant_id = plant_id
         self._attr_unique_id = f"{plant_id}_{description.key}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, plant_id)},
-            name=f"Hoval {plant_data.name}",
-            manufacturer="Hoval",
-            model="Plant",
-        )
+        self._attr_device_info = plant_device_info(plant_data)
 
     @property
     def _plant(self) -> HovalPlantData | None:

--- a/custom_components/hoval_connect/strings.json
+++ b/custom_components/hoval_connect/strings.json
@@ -33,10 +33,14 @@
       "init": {
         "title": "Hoval Connect Options",
         "data": {
-          "override_duration": "Temporary override duration"
+          "turn_on_mode": "Turn-on mode",
+          "override_duration": "Temporary override duration",
+          "scan_interval": "Polling interval"
         },
         "data_description": {
-          "override_duration": "How long a manual fan speed change lasts before the time program resumes."
+          "turn_on_mode": "What happens when the fan is turned on from standby.",
+          "override_duration": "How long a manual fan speed change lasts before the time program resumes.",
+          "scan_interval": "How often to poll the Hoval API for updates."
         }
       }
     }
@@ -66,6 +70,9 @@
       "humidity_target": {
         "name": "Target humidity"
       },
+      "operation_mode": {
+        "name": "Operation mode"
+      },
       "active_week_program": {
         "name": "Week program"
       },
@@ -86,6 +93,24 @@
       },
       "active_events": {
         "name": "Active events"
+      },
+      "weather_condition": {
+        "name": "Weather"
+      },
+      "weather_temperature": {
+        "name": "Forecast temperature"
+      }
+    },
+    "select": {
+      "program": {
+        "name": "Program",
+        "state": {
+          "week1": "Week 1",
+          "week2": "Week 2",
+          "ecoMode": "Eco mode",
+          "standby": "Standby",
+          "constant": "Constant"
+        }
       }
     }
   }

--- a/custom_components/hoval_connect/strings.json
+++ b/custom_components/hoval_connect/strings.json
@@ -107,7 +107,7 @@
         "state": {
           "week1": "Week 1",
           "week2": "Week 2",
-          "ecoMode": "Eco mode",
+          "eco_mode": "Eco mode",
           "standby": "Standby",
           "constant": "Constant"
         }

--- a/custom_components/hoval_connect/strings.json
+++ b/custom_components/hoval_connect/strings.json
@@ -101,6 +101,16 @@
         "name": "Forecast temperature"
       }
     },
+    "climate": {
+      "heating": {
+        "name": "Heating"
+      }
+    },
+    "fan": {
+      "ventilation": {
+        "name": "Ventilation"
+      }
+    },
     "select": {
       "program": {
         "name": "Program",

--- a/custom_components/hoval_connect/translations/en.json
+++ b/custom_components/hoval_connect/translations/en.json
@@ -107,7 +107,7 @@
         "state": {
           "week1": "Week 1",
           "week2": "Week 2",
-          "ecoMode": "Eco mode",
+          "eco_mode": "Eco mode",
           "standby": "Standby",
           "constant": "Constant"
         }

--- a/custom_components/hoval_connect/translations/en.json
+++ b/custom_components/hoval_connect/translations/en.json
@@ -34,11 +34,13 @@
         "title": "Hoval Connect Options",
         "data": {
           "turn_on_mode": "Turn-on mode",
-          "override_duration": "Temporary override duration"
+          "override_duration": "Temporary override duration",
+          "scan_interval": "Polling interval"
         },
         "data_description": {
           "turn_on_mode": "What happens when the fan is turned on from standby.",
-          "override_duration": "How long a manual fan speed change lasts before the time program resumes."
+          "override_duration": "How long a manual fan speed change lasts before the time program resumes.",
+          "scan_interval": "How often to poll the Hoval API for updates."
         }
       }
     }
@@ -68,6 +70,9 @@
       "humidity_target": {
         "name": "Target humidity"
       },
+      "operation_mode": {
+        "name": "Operation mode"
+      },
       "active_week_program": {
         "name": "Week program"
       },
@@ -88,6 +93,24 @@
       },
       "active_events": {
         "name": "Active events"
+      },
+      "weather_condition": {
+        "name": "Weather"
+      },
+      "weather_temperature": {
+        "name": "Forecast temperature"
+      }
+    },
+    "select": {
+      "program": {
+        "name": "Program",
+        "state": {
+          "week1": "Week 1",
+          "week2": "Week 2",
+          "ecoMode": "Eco mode",
+          "standby": "Standby",
+          "constant": "Constant"
+        }
       }
     }
   }

--- a/custom_components/hoval_connect/translations/en.json
+++ b/custom_components/hoval_connect/translations/en.json
@@ -101,6 +101,16 @@
         "name": "Forecast temperature"
       }
     },
+    "climate": {
+      "heating": {
+        "name": "Heating"
+      }
+    },
+    "fan": {
+      "ventilation": {
+        "name": "Ventilation"
+      }
+    },
     "select": {
       "program": {
         "name": "Program",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Hoval Connect integration."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -21,6 +21,7 @@ sys.modules["homeassistant.helpers"] = ha_mock
 sys.modules["homeassistant.helpers.update_coordinator"] = ha_mock
 sys.modules["homeassistant.helpers.aiohttp_client"] = ha_mock
 sys.modules["homeassistant.helpers.device_registry"] = ha_mock
+sys.modules["homeassistant.helpers.dispatcher"] = ha_mock
 sys.modules["homeassistant.util"] = ha_mock
 sys.modules["homeassistant.util.dt"] = ha_mock
 sys.modules["aiohttp"] = ha_mock

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,180 @@
+"""Tests for the Hoval Connect coordinator logic (pure functions).
+
+These tests cover the pure utility functions that don't depend on Home Assistant.
+They can be run without homeassistant installed by using sys.path manipulation.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from unittest.mock import MagicMock
+
+# Mock homeassistant modules so we can import the coordinator's pure functions
+ha_mock = MagicMock()
+sys.modules["homeassistant"] = ha_mock
+sys.modules["homeassistant.config_entries"] = ha_mock
+sys.modules["homeassistant.const"] = ha_mock
+sys.modules["homeassistant.core"] = ha_mock
+sys.modules["homeassistant.exceptions"] = ha_mock
+sys.modules["homeassistant.helpers"] = ha_mock
+sys.modules["homeassistant.helpers.update_coordinator"] = ha_mock
+sys.modules["homeassistant.helpers.aiohttp_client"] = ha_mock
+sys.modules["homeassistant.helpers.device_registry"] = ha_mock
+sys.modules["homeassistant.util"] = ha_mock
+sys.modules["homeassistant.util.dt"] = ha_mock
+sys.modules["aiohttp"] = ha_mock
+sys.modules["voluptuous"] = ha_mock
+
+# Now we can import the pure functions and dataclasses
+from custom_components.hoval_connect.coordinator import (  # noqa: E402
+    HovalCircuitData,
+    _resolve_active_program_value,
+    resolve_fan_speed,
+)
+
+
+class TestResolveFanSpeed:
+    """Tests for resolve_fan_speed()."""
+
+    def test_none_circuit_returns_default(self):
+        assert resolve_fan_speed(None) == 40
+
+    def test_live_air_volume(self):
+        circuit = HovalCircuitData(
+            circuit_type="HV", path="1.2.3", name="Test",
+            live_values={"airVolume": "65"},
+        )
+        assert resolve_fan_speed(circuit) == 65
+
+    def test_live_air_volume_float(self):
+        circuit = HovalCircuitData(
+            circuit_type="HV", path="1.2.3", name="Test",
+            live_values={"airVolume": "72.5"},
+        )
+        assert resolve_fan_speed(circuit) == 72
+
+    def test_live_zero_falls_through(self):
+        circuit = HovalCircuitData(
+            circuit_type="HV", path="1.2.3", name="Test",
+            live_values={"airVolume": "0"},
+            target_air_volume=50,
+        )
+        assert resolve_fan_speed(circuit) == 50
+
+    def test_target_air_volume_fallback(self):
+        circuit = HovalCircuitData(
+            circuit_type="HV", path="1.2.3", name="Test",
+            target_air_volume=80,
+        )
+        assert resolve_fan_speed(circuit) == 80
+
+    def test_program_air_volume_fallback(self):
+        circuit = HovalCircuitData(
+            circuit_type="HV", path="1.2.3", name="Test",
+            program_air_volume=55.0,
+        )
+        assert resolve_fan_speed(circuit) == 55
+
+    def test_all_none_returns_default(self):
+        circuit = HovalCircuitData(
+            circuit_type="HV", path="1.2.3", name="Test",
+        )
+        assert resolve_fan_speed(circuit) == 40
+
+    def test_minimum_is_one(self):
+        circuit = HovalCircuitData(
+            circuit_type="HV", path="1.2.3", name="Test",
+            live_values={"airVolume": "0"},
+            target_air_volume=0,
+            program_air_volume=0.0,
+        )
+        assert resolve_fan_speed(circuit) == 40  # falls through to default
+
+
+class TestResolveActiveProgramValue:
+    """Tests for _resolve_active_program_value()."""
+
+    def _make_programs(
+        self, phases: list[dict] | None = None, day_name: str = "Normal",
+    ) -> dict:
+        """Build a minimal programs structure."""
+        if phases is None:
+            phases = [
+                {"start": {"hours": 6, "minutes": 0}, "end": {"hours": 22, "minutes": 0}, "value": 60},
+                {"start": {"hours": 22, "minutes": 0}, "end": {"hours": 23, "minutes": 59}, "value": 30},
+            ]
+        return {
+            "week1": {
+                "name": "Woche 1",
+                "dayProgramIds": [1, 1, 1, 1, 1, 2, 2],  # Mon-Fri=1, Sat-Sun=2
+            },
+            "dayPrograms": {
+                "dayConfigurations": [
+                    {"id": 1, "name": day_name, "phases": phases},
+                    {"id": 2, "name": "Weekend", "phases": [
+                        {"start": {"hours": 8, "minutes": 0}, "end": {"hours": 22, "minutes": 0}, "value": 50},
+                    ]},
+                ],
+            },
+        }
+
+    def test_monday_morning(self):
+        programs = self._make_programs()
+        now = datetime(2024, 1, 8, 10, 0)  # Monday
+        week, day, value = _resolve_active_program_value(programs, now)
+        assert week == "Woche 1"
+        assert day == "Normal"
+        assert value == 60
+
+    def test_monday_night(self):
+        programs = self._make_programs()
+        now = datetime(2024, 1, 8, 23, 30)  # Monday
+        week, day, value = _resolve_active_program_value(programs, now)
+        assert week == "Woche 1"
+        assert day == "Normal"
+        assert value == 30
+
+    def test_saturday(self):
+        programs = self._make_programs()
+        now = datetime(2024, 1, 13, 12, 0)  # Saturday
+        week, day, value = _resolve_active_program_value(programs, now)
+        assert week == "Woche 1"
+        assert day == "Weekend"
+        assert value == 50
+
+    def test_no_matching_phase(self):
+        programs = self._make_programs()
+        now = datetime(2024, 1, 8, 4, 0)  # Monday 4 AM
+        week, day, value = _resolve_active_program_value(programs, now)
+        assert week == "Woche 1"
+        assert day == "Normal"
+        assert value is None
+
+    def test_empty_programs(self):
+        programs = {}
+        now = datetime(2024, 1, 8, 10, 0)
+        week, day, value = _resolve_active_program_value(programs, now)
+        assert week is None
+        assert day is None
+        assert value is None
+
+    def test_empty_day_configurations(self):
+        programs = {"dayPrograms": {"dayConfigurations": []}}
+        now = datetime(2024, 1, 8, 10, 0)
+        week, day, value = _resolve_active_program_value(programs, now)
+        assert week is None
+        assert day is None
+        assert value is None
+
+    def test_phase_boundary_start(self):
+        programs = self._make_programs()
+        now = datetime(2024, 1, 8, 6, 0)  # Exactly at phase start
+        week, day, value = _resolve_active_program_value(programs, now)
+        assert value == 60
+
+    def test_phase_boundary_end(self):
+        programs = self._make_programs()
+        now = datetime(2024, 1, 8, 22, 0)  # Exactly at phase end/next start
+        week, day, value = _resolve_active_program_value(programs, now)
+        assert value == 30


### PR DESCRIPTION
## Summary

Major feature and quality release for the Hoval Connect integration:

- **Climate platform** for HK (heating) circuits — HEAT/OFF/AUTO modes with target temperature control
- **Select entity** for week program switching (week1, week2, ecoMode, standby, constant)
- **Parallel API calls** with `asyncio.gather()` for significantly faster polling cycles
- **Program cache** (5min TTL) reduces redundant API calls
- **Weather sensors** — condition and temperature from Hoval's weather API
- **Operation mode sensor** (diagnostic) for each circuit
- **Request timeout** (30s) and automatic **token retry on 401** for robustness
- **Configurable polling interval** (30/60/120/300s) via options flow
- **DeviceInfo helpers** — eliminates duplicate device info construction across platforms
- **EntityCategory.DIAGNOSTIC** on program/event/operation sensors
- **Code quality**: replaced deprecated `ensure_future`, added debounce cleanup, extracted constants
- **16 unit tests** for pure coordinator functions (fan speed resolution, program scheduling)

### Files changed (16 files, +837 / -123)

| File | Change |
|------|--------|
| `climate.py` | **New** — HK heating circuit climate entity |
| `select.py` | **New** — Week program select entity |
| `tests/test_coordinator.py` | **New** — 16 unit tests |
| `coordinator.py` | Parallel API, program cache, weather data |
| `__init__.py` | DeviceInfo helpers, configurable polling, options listener |
| `api.py` | Request timeout, token retry, public invalidate method |
| `sensor.py` | Weather + operation mode sensors, diagnostic categories |
| `fan.py` | DeviceInfo helper, constants, async_create_task, cleanup |
| `const.py` | New constants (timeout, cache TTL, scan interval, circuit names) |
| `config_flow.py` | Polling interval option |
| `binary_sensor.py` | DeviceInfo helper |
| `strings.json` / `translations/en.json` | New entity translations |
| `manifest.json` | Version bump to 0.10.0 |
| `CLAUDE.md` | Updated documentation |

## Test plan

- [x] Ruff lint passes (no errors)
- [x] 16 unit tests pass (`pytest tests/`)
- [ ] Manual test: HK climate entity shows current/target temperature
- [ ] Manual test: Select entity switches between week programs
- [ ] Manual test: Weather sensors display condition and temperature
- [ ] Manual test: Options flow allows changing polling interval
- [ ] Manual test: Token retry works when session expires mid-poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)