### PR TITLE
feat: Add common sensor to show status of circuit

### DIFF
--- a/custom_components/hoval_connect/sensor.py
+++ b/custom_components/hoval_connect/sensor.py
@@ -92,6 +92,12 @@ CIRCUIT_SENSOR_DESCRIPTIONS: tuple[HovalSensorEntityDescription, ...] = (
         value_fn=lambda c: c.live_values.get("humidityTarget"),
     ),
     HovalSensorEntityDescription(
+        key="circuit_status",
+        translation_key="circuit_status",
+        icon="mdi:information-outline",
+        value_fn=lambda c: c.live_values.get("status"),
+    ),
+    HovalSensorEntityDescription(
         key="operation_mode",
         translation_key="operation_mode",
         icon="mdi:cog",

--- a/custom_components/hoval_connect/strings.json
+++ b/custom_components/hoval_connect/strings.json
@@ -70,6 +70,9 @@
       "humidity_target": {
         "name": "Target humidity"
       },
+      "circuit_status": {
+        "name": "Status"
+      },
       "operation_mode": {
         "name": "Operation mode"
       },

--- a/custom_components/hoval_connect/translations/de.json
+++ b/custom_components/hoval_connect/translations/de.json
@@ -70,6 +70,9 @@
       "humidity_target": {
         "name": "Feuchtigkeit Soll"
       },
+      "circuit_status": {
+        "name": "Status"
+      },
       "operation_mode": {
         "name": "Betriebsmodus"
       },

--- a/custom_components/hoval_connect/translations/en.json
+++ b/custom_components/hoval_connect/translations/en.json
@@ -70,6 +70,9 @@
       "humidity_target": {
         "name": "Target humidity"
       },
+      "circuit_status": {
+        "name": "Status"
+      },
       "operation_mode": {
         "name": "Operation mode"
       },


### PR DESCRIPTION
It seems that all circuits provide the status as string value. On module WEZ/circuit BL (UltraSource comfort c) the status value is updated with delay.
Since all circuit types deliver different string values, showing the raw string value seemed the most feasible approach. More elegant way would be to have a dedicated enum sensor per circuit type but it would require to figure out all state values of all the different circuit types and hoval devices.